### PR TITLE
Separate Upstream and Downstream Module

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "hashicorp.terraform"
+    ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "hashicorp.terraform"
+        "hashicorp.terraform",
+        "dannysteenman.aws-terraform-extension-pack"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "aws.telemetry": false
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,8 +37,8 @@ module "rabbit_downstream" {
   is_public = true
   upstream_broker_amqps_endpoint = module.rabbit_upstream.broker_amqps_endpoint
   upstream_rabbit_creds = {
-    username = module.rabbit_upstream.rabbit_admin_creds["username"]
-    password = module.rabbit_upstream.rabbit_admin_creds["password"]
+    username = module.rabbit_upstream.rabbit_queue_user_creds["username"]
+    password = module.rabbit_upstream.rabbit_queue_user_creds["password"]
   }
   upstream_vhost_name = local.vhost_name
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -39,21 +39,21 @@ module "rabbit_upstream" {
   is_public = true
 }
 
-# module "rabbit_downstream" {
-#   source = "./modules/rabbit_downstream"
-#   name_base = "RabbitDownstream"
-#   subnet_ids = [module.vpc.public_subnets[0]]
-#   vhost_name = local.vhost_name
-#   queue_name = local.queue_name
-#   is_ha = false
-#   is_public = true
-#   upstream_broker_amqps_endpoint = module.rabbit_broker_upstream.rabbit_mq_broker_https_endpoint
-#   upstream_rabbit_creds = {
-#     username = module.rabbit_upstream.rabbit_queue_user_creds["username"]
-#     password = module.rabbit_upstream.rabbit_queue_user_creds["password"]
-#   }
-#   upstream_vhost_name = local.vhost_name
-# }
+module "rabbit_downstream" {
+  source = "./modules/rabbit_downstream"
+  name_base = "RabbitDownstream"
+  subnet_ids = [module.vpc.public_subnets[0]]
+  vhost_name = local.vhost_name
+  queue_name = local.queue_name
+  is_ha = false
+  is_public = true
+  upstream_broker_amqps_endpoint = module.rabbit_broker_upstream.rabbit_mq_broker_amqps_endpoint
+  upstream_rabbit_creds = {
+    username = module.rabbit_upstream.rabbit_queue_user_creds["username"]
+    password = module.rabbit_upstream.rabbit_queue_user_creds["password"]
+  }
+  upstream_vhost_name = local.vhost_name
+}
 
 
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -49,8 +49,8 @@ module "rabbit_downstream" {
   is_public = true
   upstream_broker_amqps_endpoint = module.rabbit_upstream.broker_amqps_endpoint
   upstream_rabbit_creds = {
-    username = module.rabbit_upstream.rabbit_queue_user_creds["username"]
-    password = module.rabbit_upstream.rabbit_queue_user_creds["password"]
+    username = module.rabbit_upstream.rabbit_admin_creds["username"]
+    password = module.rabbit_upstream.rabbit_admin_creds["password"]
   }
   upstream_vhost_name = local.vhost_name
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,87 +29,34 @@ module "rabbit_broker_upstream" {
   subnet_ids = module.vpc.public_subnets
 }
 
-data "aws_secretsmanager_secret_version" "downstream_rabbit_mq_admin" {
-  secret_id = module.rabbit_broker_downstream.rabbit_mq_secret_arn
+module "rabbit_upstream" {
+  source = "./modules/rabbit_upstream"
+  name_base = "RabbitUpstream"
+  subnet_ids = [module.vpc.public_subnets[0]]
+  vhost_name = local.vhost_name
+  queue_name = local.queue_name
+  is_ha = false
+  is_public = true
 }
 
-data "aws_secretsmanager_secret_version" "upstream_rabbit_mq_admin" {
-  secret_id = module.rabbit_broker_upstream.rabbit_mq_secret_arn
-}
+# module "rabbit_downstream" {
+#   source = "./modules/rabbit_downstream"
+#   name_base = "RabbitDownstream"
+#   subnet_ids = [module.vpc.public_subnets[0]]
+#   vhost_name = local.vhost_name
+#   queue_name = local.queue_name
+#   is_ha = false
+#   is_public = true
+#   upstream_broker_amqps_endpoint = module.rabbit_broker_upstream.rabbit_mq_broker_https_endpoint
+#   upstream_rabbit_creds = {
+#     username = module.rabbit_upstream.rabbit_queue_user_creds["username"]
+#     password = module.rabbit_upstream.rabbit_queue_user_creds["password"]
+#   }
+#   upstream_vhost_name = local.vhost_name
+# }
 
-locals {
-  downstream_username = jsondecode("${data.aws_secretsmanager_secret_version.downstream_rabbit_mq_admin.secret_string}")["username"]
-  downstream_password = jsondecode("${data.aws_secretsmanager_secret_version.downstream_rabbit_mq_admin.secret_string}")["password"]
-  upstream_username = jsondecode("${data.aws_secretsmanager_secret_version.upstream_rabbit_mq_admin.secret_string}")["username"]
-  upstream_password = jsondecode("${data.aws_secretsmanager_secret_version.upstream_rabbit_mq_admin.secret_string}")["password"]
-}
 
-provider "rabbitmq" {
-  alias = "downstream"
-  endpoint = module.rabbit_broker_downstream.rabbit_mq_broker_https_endpoint
-  username = local.downstream_username
-  password = local.downstream_password
-}
 
-provider "rabbitmq" {
-  alias = "upstream"
-  endpoint = module.rabbit_broker_upstream.rabbit_mq_broker_https_endpoint
-  username = local.upstream_username
-  password = local.upstream_password
-}
 
-resource "rabbitmq_vhost" "upstream" {
-  provider = rabbitmq.upstream
-  name = local.vhost_name
-}
 
-resource "rabbitmq_vhost" "downstream" {
-  provider = rabbitmq.downstream
-  name = local.vhost_name
-}
 
-locals {
-  upstream_endpoint_amqps_trimmed = trimprefix(module.rabbit_broker_upstream.rabbit_mq_broker_amqps_endpoint, "amqps://")
-  upstream_endpoint_amqps_auth = "amqps://${local.upstream_username}:${local.upstream_password}@${local.upstream_endpoint_amqps_trimmed}/${rabbitmq_vhost.upstream.name}"
-}
-
-resource "rabbitmq_federation_upstream" "this" {
-  provider = rabbitmq.downstream
-  name = "FederationToUpstream"
-  vhost = rabbitmq_vhost.downstream.name
-  definition {
-    uri = local.upstream_endpoint_amqps_auth
-  }
-}
-
-resource "rabbitmq_queue" "upstream" {
-  provider = rabbitmq.upstream
-  name = local.queue_name
-  settings {
-    durable = true
-    auto_delete = false
-  }
-  vhost = rabbitmq_vhost.upstream.name
-}
-
-resource "rabbitmq_queue" "downstream" {
-  provider = rabbitmq.downstream
-  name = local.queue_name
-  settings {
-    durable = true
-    auto_delete = false
-  }
-  vhost = rabbitmq_vhost.downstream.name
-}
-
-resource "rabbitmq_policy" "connect_to_upstream_queue" {
-  provider = rabbitmq.downstream
-  name = "PullFromUpstreamQueue"
-  vhost = rabbitmq_vhost.downstream.name
-  policy {
-    apply_to = "queues"
-    definition = {"federation-upstream-set": "all"}
-    pattern = rabbitmq_queue.upstream.name
-    priority = 10
-  }
-}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -47,7 +47,7 @@ module "rabbit_downstream" {
   queue_name = local.queue_name
   is_ha = false
   is_public = true
-  upstream_broker_amqps_endpoint = module.rabbit_broker_upstream.rabbit_mq_broker_amqps_endpoint
+  upstream_broker_amqps_endpoint = module.rabbit_upstream.broker_amqps_endpoint
   upstream_rabbit_creds = {
     username = module.rabbit_upstream.rabbit_queue_user_creds["username"]
     password = module.rabbit_upstream.rabbit_queue_user_creds["password"]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -17,18 +17,6 @@ module "vpc" {
   nat = var.nat
 }
 
-module "rabbit_broker_downstream" {
-  source = "./modules/rabbit_broker"
-  name_base = "RabbitBrokerDownstream"
-  subnet_ids = module.vpc.public_subnets
-}
-
-module "rabbit_broker_upstream" {
-  source = "./modules/rabbit_broker"
-  name_base = "RabbitBrokerUpstream"
-  subnet_ids = module.vpc.public_subnets
-}
-
 module "rabbit_upstream" {
   source = "./modules/rabbit_upstream"
   name_base = "RabbitUpstream"

--- a/terraform/modules/rabbit_broker/rabbit_broker.tf
+++ b/terraform/modules/rabbit_broker/rabbit_broker.tf
@@ -7,27 +7,6 @@ terraform {
   }
 }
 
-# variable "queues" {
-#   description = "A map of objects representing the queues to be created and their setting. The key will be the name of the queue"
-#   type = map(object({
-#     durable = bool
-#     auto_delete = bool
-#     upstream_policy = optional(object({
-#       priority = number
-#       definition = map(string)
-#     }))
-#   }))
-# }
-
-# variable "upstream" {
-#   description = "Optional: Provide an object to connect to an upstream host."
-#   type = object({
-#     secret_arn = string
-#     endpoint_uri = string
-#   })
-#   nullable = true
-# }
-
 resource "random_password" "rabbit_mq_admin" {
   length = 16
   special = false

--- a/terraform/modules/rabbit_downstream/outputs.tf
+++ b/terraform/modules/rabbit_downstream/outputs.tf
@@ -1,0 +1,19 @@
+output "broker_arn" {
+  value = aws_mq_broker.rabbit.arn
+  description = "ARN of the Rabbit MQ Broker"
+}
+
+output "broker_amqps_endpoint" {
+  value = aws_mq_broker.rabbit.instances.0.endpoints.0
+  description = "Endpoint of the Rabbit MQ Broker"
+}
+
+output "broker_https_endpoint" {
+  value = aws_mq_broker.rabbit.instances.0.console_url
+  description = "Endpoint of the Rabbit MQ Broker"
+}
+
+output "rabbit_admin_secret_arn" {
+  value = aws_secretsmanager_secret.rabbit_admin.arn
+  description = "ARN of the Rabbit MQ Secret"
+}

--- a/terraform/modules/rabbit_downstream/rabbit_downstream.tf
+++ b/terraform/modules/rabbit_downstream/rabbit_downstream.tf
@@ -1,0 +1,125 @@
+terraform {
+  required_providers {
+    rabbitmq = {
+      source = "rfd59/rabbitmq"
+      version = "2.3.0"
+    }
+  }
+}
+
+resource "random_password" "rabbit_admin" {
+  length = 32
+  special = false
+  min_lower = 1
+  min_numeric = 1
+  min_upper = 1
+}
+
+resource "aws_secretsmanager_secret" "rabbit_admin" {
+  name = "${var.name_base}/RabbitAdmin"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "rabbit_admin" {
+  secret_id     = aws_secretsmanager_secret.rabbit_admin.arn
+  secret_string = jsonencode({
+    username    = "RabbitAdmin"
+    password    = "${random_password.rabbit_admin.result}"
+  })
+}
+
+resource "aws_secretsmanager_secret" "rabbit_upstream_federation_user" {
+  name = "${var.name_base}/RabbitUpstreamFederationUser"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "rabbit_upstream_federation_user" {
+  secret_id     = aws_secretsmanager_secret.rabbit_upstream_federation_user.arn
+  secret_string = jsonencode({
+    username    = var.upstream_rabbit_creds["username"]
+    password    = var.upstream_rabbit_creds["password"]
+  })
+}
+
+data "aws_secretsmanager_secret_version" "rabbit_admin" {
+  secret_id = aws_secretsmanager_secret.rabbit_admin.arn
+}
+
+locals {
+  rabbit_admin_username = (jsondecode("${data.aws_secretsmanager_secret_version.rabbit_admin.secret_string}"))["username"]
+  rabbit_admin_password = (jsondecode("${data.aws_secretsmanager_secret_version.rabbit_admin.secret_string}"))["password"]
+  upstream_endpoint_amqps_trimmed = trimprefix(var.upstream_broker_amqps_endpoint, "amqps://")
+  upstream_endpoint_amqps_auth = "amqps://${var.upstream_rabbit_creds["username"]}:${var.upstream_rabbit_creds["password"]}@${local.upstream_endpoint_amqps_trimmed}/${var.upstream_vhost_name}"
+}
+
+resource "aws_mq_broker" "rabbit" {
+  broker_name = "${var.name_base}-Rabbit"
+  engine_type = "RabbitMQ"
+  engine_version = "3.13"
+  host_instance_type = "mq.t3.micro"
+  auto_minor_version_upgrade = true
+  publicly_accessible = true
+  apply_immediately = true
+  subnet_ids = var.subnet_ids
+  user {
+    username = local.rabbit_admin_username
+    password = local.rabbit_admin_password
+  }
+  deployment_mode = var.is_ha ? "CLUSTER_MULTI_AZ" : "SINGLE_INSTANCE"
+  logs {
+    general = true
+  }
+}
+
+provider "rabbitmq" {
+  endpoint = aws_mq_broker.rabbit.instances.0.console_url
+  username = local.rabbit_admin_username
+  password = local.rabbit_admin_password
+}
+
+resource "rabbitmq_vhost" "this" {
+  provider = rabbitmq
+  name = var.vhost_name
+}
+
+provider "rabbitmq" {
+  alias = "downstream"
+  endpoint = aws_mq_broker.rabbit.instances.0.console_url
+  username = local.rabbit_admin_password
+  password = local.rabbit_admin_password
+}
+
+resource "rabbitmq_federation_upstream" "this" {
+  name = "FederationToUpstream"
+  vhost = var.vhost_name
+  definition {
+    uri = local.upstream_endpoint_amqps_auth
+  }
+}
+
+resource "rabbitmq_queue" "this" {
+  name = var.queue_name
+  settings {
+    durable = true
+    auto_delete = false
+  }
+  vhost = var.vhost_name
+}
+
+resource "rabbitmq_policy" "connect_to_upstream_queue" {
+  name = "PullFromUpstreamQueue"
+  vhost = rabbitmq_vhost.this.name
+  policy {
+    apply_to = "queues"
+    definition = {"federation-upstream-set": "all"}
+    pattern = var.queue_name
+    priority = 10
+  }
+}
+
+
+
+
+
+
+

--- a/terraform/modules/rabbit_downstream/rabbit_downstream.tf
+++ b/terraform/modules/rabbit_downstream/rabbit_downstream.tf
@@ -30,6 +30,7 @@ resource "aws_secretsmanager_secret_version" "rabbit_admin" {
 
 data "aws_secretsmanager_secret_version" "rabbit_admin" {
   secret_id = aws_secretsmanager_secret.rabbit_admin.arn
+  version_id = aws_secretsmanager_secret_version.rabbit_admin.version_id
 }
 
 resource "aws_secretsmanager_secret" "rabbit_upstream_federation_user" {
@@ -104,7 +105,7 @@ resource "rabbitmq_policy" "connect_to_upstream_queue" {
   policy {
     apply_to = "queues"
     definition = {"federation-upstream-set": "all"}
-    pattern = var.queue_name
+    pattern = rabbitmq_queue.this.name
     priority = 10
   }
 }

--- a/terraform/modules/rabbit_downstream/rabbit_downstream.tf
+++ b/terraform/modules/rabbit_downstream/rabbit_downstream.tf
@@ -28,6 +28,10 @@ resource "aws_secretsmanager_secret_version" "rabbit_admin" {
   })
 }
 
+data "aws_secretsmanager_secret_version" "rabbit_admin" {
+  secret_id = aws_secretsmanager_secret.rabbit_admin.arn
+}
+
 resource "aws_secretsmanager_secret" "rabbit_upstream_federation_user" {
   name = "${var.name_base}/RabbitUpstreamFederationUser"
   recovery_window_in_days = 0
@@ -39,10 +43,6 @@ resource "aws_secretsmanager_secret_version" "rabbit_upstream_federation_user" {
     username    = var.upstream_rabbit_creds["username"]
     password    = var.upstream_rabbit_creds["password"]
   })
-}
-
-data "aws_secretsmanager_secret_version" "rabbit_admin" {
-  secret_id = aws_secretsmanager_secret.rabbit_admin.arn
 }
 
 locals {
@@ -91,7 +91,7 @@ provider "rabbitmq" {
 
 resource "rabbitmq_federation_upstream" "this" {
   name = "FederationToUpstream"
-  vhost = var.vhost_name
+  vhost = rabbitmq_vhost.this.name
   definition {
     uri = local.upstream_endpoint_amqps_auth
   }
@@ -103,7 +103,7 @@ resource "rabbitmq_queue" "this" {
     durable = true
     auto_delete = false
   }
-  vhost = var.vhost_name
+  vhost = rabbitmq_vhost.this.name
 }
 
 resource "rabbitmq_policy" "connect_to_upstream_queue" {

--- a/terraform/modules/rabbit_downstream/rabbit_downstream.tf
+++ b/terraform/modules/rabbit_downstream/rabbit_downstream.tf
@@ -78,15 +78,7 @@ provider "rabbitmq" {
 }
 
 resource "rabbitmq_vhost" "this" {
-  provider = rabbitmq
   name = var.vhost_name
-}
-
-provider "rabbitmq" {
-  alias = "downstream"
-  endpoint = aws_mq_broker.rabbit.instances.0.console_url
-  username = local.rabbit_admin_password
-  password = local.rabbit_admin_password
 }
 
 resource "rabbitmq_federation_upstream" "this" {

--- a/terraform/modules/rabbit_downstream/variables.tf
+++ b/terraform/modules/rabbit_downstream/variables.tf
@@ -1,0 +1,51 @@
+variable "name_base" {
+  type = string
+  description = "Name the resources in this module should be based on."
+}
+
+variable "subnet_ids" {
+  type = list(string)
+  description = "List of subnets to deploy the RabbitMQ broker in."
+}
+
+variable "vhost_name" {
+  type = string
+  description = "Name of the virtual host to create that the queue is created in."
+}
+
+variable "queue_name" {
+  type = string
+  description = "Name of the queue to create."
+}
+
+variable "is_public" {
+  type = bool
+  description = "Whether the broker should be public or not."
+  default = false
+}
+
+variable "is_ha" {
+  type = bool
+  description = "Whether the broker should be clustered for high availability or not."
+}
+
+variable "upstream_broker_amqps_endpoint" {
+  type = string
+  description = "The AMQPS endpoint of the upstream broker to federate with."
+  default = null
+}
+
+variable "upstream_vhost_name" {
+  type = string
+  description = "The name of the virtual host on the upstream broker to federate with."
+}
+
+variable "upstream_rabbit_creds" {
+  type = object({
+    username = string
+    password = string
+  })
+  description = "The RabbitMQ credentials to use to authenticate with the upstream broker."
+  sensitive = true
+}
+

--- a/terraform/modules/rabbit_upstream/outputs.tf
+++ b/terraform/modules/rabbit_upstream/outputs.tf
@@ -31,3 +31,12 @@ output "rabbit_queue_user_creds" {
   description = "The Credentials for the Queue User created"
   sensitive = true
 }
+
+output "rabbit_admin_creds" {
+  value = {
+    username = jsondecode("${data.aws_secretsmanager_secret_version.rabbit_admin.secret_string}")["username"]
+    password = jsondecode("${data.aws_secretsmanager_secret_version.rabbit_admin.secret_string}")["password"]
+  }
+  description = "The Credentials for the Admin User created"
+  sensitive = true
+}

--- a/terraform/modules/rabbit_upstream/outputs.tf
+++ b/terraform/modules/rabbit_upstream/outputs.tf
@@ -1,0 +1,33 @@
+output "broker_arn" {
+  value = aws_mq_broker.rabbit.arn
+  description = "ARN of the Rabbit MQ Broker"
+}
+
+output "broker_amqps_endpoint" {
+  value = aws_mq_broker.rabbit.instances.0.endpoints.0
+  description = "Endpoint of the Rabbit MQ Broker"
+}
+
+output "broker_https_endpoint" {
+  value = aws_mq_broker.rabbit.instances.0.console_url
+  description = "Endpoint of the Rabbit MQ Broker"
+}
+
+output "rabbit_admin_secret_arn" {
+  value = aws_secretsmanager_secret.rabbit_admin.arn
+  description = "ARN of the Rabbit MQ Secret"
+}
+
+output "rabbit_queue_user_creds_secret_arn"  {
+  value = aws_secretsmanager_secret.rabbit_queue_user.arn
+  description = "ARN of the Rabbit Queue User Secret"
+}
+
+output "rabbit_queue_user_creds" {
+  value = {
+    username = jsondecode("${data.aws_secretsmanager_secret_version.rabbit_queue_user.secret_string}")["username"]
+    password = jsondecode("${data.aws_secretsmanager_secret_version.rabbit_queue_user.secret_string}")["password"]
+  }
+  description = "The Credentials for the Queue User created"
+  sensitive = true
+}

--- a/terraform/modules/rabbit_upstream/rabbit_upstream.tf
+++ b/terraform/modules/rabbit_upstream/rabbit_upstream.tf
@@ -1,0 +1,127 @@
+terraform {
+  required_providers {
+    rabbitmq = {
+      source = "rfd59/rabbitmq"
+      version = "2.3.0"
+    }
+  }
+}
+
+resource "random_password" "rabbit_admin" {
+  length = 32
+  special = false
+  min_lower = 1
+  min_numeric = 1
+  min_upper = 1
+}
+
+resource "aws_secretsmanager_secret" "rabbit_admin" {
+  name = "${var.name_base}/RabbitAdmin"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "rabbit_admin" {
+  secret_id     = aws_secretsmanager_secret.rabbit_admin.arn
+  secret_string = jsonencode({
+    username    = "RabbitAdmin"
+    password    = "${random_password.rabbit_admin.result}"
+  })
+}
+
+resource "random_password" "rabbit_queue_user" {
+  length = 32
+  special = false
+  min_lower = 1
+  min_numeric = 1
+  min_upper = 1
+}
+
+resource "aws_secretsmanager_secret" "rabbit_queue_user" {
+  name = "${var.name_base}/RabbitQueueUser"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "rabbit_queue_user" {
+  secret_id     = aws_secretsmanager_secret.rabbit_queue_user.arn
+  secret_string = jsonencode({
+    username    = "RabbitQueueUser"
+    password    = "${random_password.rabbit_queue_user.result}"
+  })
+}
+
+data "aws_secretsmanager_secret_version" "rabbit_admin" {
+  secret_id = aws_secretsmanager_secret.rabbit_admin.arn
+}
+
+resource "aws_mq_broker" "rabbit" {
+  broker_name = "${var.name_base}-Rabbit"
+  engine_type = "RabbitMQ"
+  engine_version = "3.13"
+  host_instance_type = "mq.t3.micro"
+  auto_minor_version_upgrade = true
+  publicly_accessible = var.is_public ? true : false
+  apply_immediately = true
+  subnet_ids = var.subnet_ids
+  user {
+    username = local.rabbit_admin_username
+    password = local.rabbit_admin_password
+  }
+  deployment_mode = var.is_ha ? "CLUSTER_MULTI_AZ" : "SINGLE_INSTANCE"
+  logs {
+    general = true
+  }
+}
+
+locals {
+  rabbit_admin_username = (jsondecode("${data.aws_secretsmanager_secret_version.rabbit_admin.secret_string}"))["username"]
+  rabbit_admin_password = (jsondecode("${data.aws_secretsmanager_secret_version.rabbit_admin.secret_string}"))["password"]
+  #endpoint_amqps_trimmed = trimprefix("${aws_mq_broker.rabbit.instances.0.console_url}", "amqps://")
+  #endpoint_amqps_auth = "amqps://${var.upstream_rabbit_creds["username"]}:${var.upstream_rabbit_creds["password"]}@${local.upstream_endpoint_amqps_trimmed}/${var.upstream_vhost_name}"
+}
+
+provider "rabbitmq" {
+  endpoint = "${aws_mq_broker.rabbit.instances.0.console_url}"
+  username = local.rabbit_admin_username
+  password = local.rabbit_admin_password
+}
+
+resource "rabbitmq_vhost" "this" {
+  name = var.vhost_name
+}
+
+resource "rabbitmq_queue" "this" {
+  name = var.queue_name
+  settings {
+    durable = true
+    auto_delete = false
+  }
+  vhost = var.vhost_name
+}
+
+data "aws_secretsmanager_secret_version" "rabbit_queue_user" {
+  secret_id = aws_secretsmanager_secret.rabbit_queue_user.id
+  version_id = aws_secretsmanager_secret_version.rabbit_queue_user.version_id
+}
+
+resource "rabbitmq_user" "rabbit_queue_user" {
+  name = (jsondecode("${data.aws_secretsmanager_secret_version.rabbit_queue_user.secret_string}"))["username"]
+  password = (jsondecode("${data.aws_secretsmanager_secret_version.rabbit_queue_user.secret_string}"))["password"]
+}
+
+resource "rabbitmq_permissions" "rabbit_queue_user" {
+  user = rabbitmq_user.rabbit_queue_user.name
+  vhost = rabbitmq_vhost.this.name
+  permissions {
+    configure = ""
+    write     = ""
+    read      = rabbitmq_queue.this.name
+  }
+}
+
+
+
+
+
+
+
+

--- a/terraform/modules/rabbit_upstream/rabbit_upstream.tf
+++ b/terraform/modules/rabbit_upstream/rabbit_upstream.tf
@@ -75,8 +75,6 @@ resource "aws_mq_broker" "rabbit" {
 locals {
   rabbit_admin_username = (jsondecode("${data.aws_secretsmanager_secret_version.rabbit_admin.secret_string}"))["username"]
   rabbit_admin_password = (jsondecode("${data.aws_secretsmanager_secret_version.rabbit_admin.secret_string}"))["password"]
-  #endpoint_amqps_trimmed = trimprefix("${aws_mq_broker.rabbit.instances.0.console_url}", "amqps://")
-  #endpoint_amqps_auth = "amqps://${var.upstream_rabbit_creds["username"]}:${var.upstream_rabbit_creds["password"]}@${local.upstream_endpoint_amqps_trimmed}/${var.upstream_vhost_name}"
 }
 
 provider "rabbitmq" {
@@ -114,7 +112,7 @@ resource "rabbitmq_permissions" "rabbit_queue_user" {
   permissions {
     configure = ""
     write     = ""
-    read      = rabbitmq_queue.this.name
+    read      = "^${rabbitmq_queue.this.name}$"
   }
 }
 

--- a/terraform/modules/rabbit_upstream/variables.tf
+++ b/terraform/modules/rabbit_upstream/variables.tf
@@ -1,0 +1,30 @@
+variable "name_base" {
+  type = string
+  description = "Name the resources in this module should be based on."
+}
+
+variable "subnet_ids" {
+  type = list(string)
+  description = "List of subnets to deploy the RabbitMQ broker in."
+}
+
+variable "vhost_name" {
+  type = string
+  description = "Name of the virtual host to create that the queue is created in."
+}
+
+variable "queue_name" {
+  type = string
+  description = "Name of the queue to create."
+}
+
+variable "is_public" {
+  type = bool
+  description = "Whether the broker should be public or not."
+  default = false
+}
+
+variable "is_ha" {
+  type = bool
+  description = "Whether the broker should be clustered for high availability or not."
+}


### PR DESCRIPTION
Two separate modules created - one for upstream and one for downstream with all logic for that rabbit broker contained within it. Both called from root module. Use specific rabbit user account for connecting to upstream in place of rabbit admin account.